### PR TITLE
Fix metricbeat yaml readstring error, value: 9200 to value: "9200"

### DIFF
--- a/pkg/controllers/metricbeat/controller.go
+++ b/pkg/controllers/metricbeat/controller.go
@@ -91,7 +91,7 @@ spec:
         - name: ELASTICSEARCH_HOST
           value: {{.ES_HOST}}
         - name: ELASTICSEARCH_PORT
-          value: {{.ES_PORT}}
+          value: "{{.ES_PORT}}"
         - name: ELASTICSEARCH_USERNAME
           value: {{.ES_USERNAME}}
         - name: ELASTICSEARCH_PASSWORD


### PR DESCRIPTION
Fix metricbeat yaml readstring error, value: 9200 to value: "9200"